### PR TITLE
pytest-filter-subpackage 0.2.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytest-filter-subpackage" %}
-{% set version = "0.1.1" %}
+{% set version = "0.2.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: b7d8fc3a42989b652032e6b0998a87dd00d43bf2b013ba5d2e86f930da149ae8
+  sha256: 3f468f1b36518128869b95deab661ba45ed6293854329fef14da4c8cac78af56
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<38]
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,16 +11,18 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<38]
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:
     - pip
     - setuptools_scm
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - pytest >=3.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,15 +23,22 @@ requirements:
     - wheel
   run:
     - python
-    - pytest >=3.0
+    - pytest >=4.6
+    - packaging
 
 test:
+  source_files:
+    - tests/
   requires:
     - pytest
     - pytest-doctestplus
     - pytest-cov
+    - pip
   imports:
     - pytest_filter_subpackage
+  commands:
+    - pip check
+    - pytest tests -vv
 
 about:
   home: https://github.com/astropy/pytest-filter-subpackage

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,14 +31,12 @@ test:
     - tests/
   requires:
     - pytest
-    - pytest-doctestplus
-    - pytest-cov
     - pip
   imports:
     - pytest_filter_subpackage
   commands:
     - pip check
-    - pytest tests -vv
+    - pytest tests -vv -k "not(test_with_rst or test_flag_single_subpackage_with_rst or test_flag_multiple_subpackage_with_rst)"
 
 about:
   home: https://github.com/astropy/pytest-filter-subpackage


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6878](https://anaconda.atlassian.net/browse/PKG-6878)
- [Upstream repository](https://github.com/astropy/pytest-filter-subpackage/tree/v0.2.0)
- [Upstream changelog/diff](https://github.com/astropy/pytest-filter-subpackage/blob/v0.2.0/CHANGES.rst)
- Relevant dependency PRs:
  - dependency for `pytest-astropy`

### Explanation of changes:

- Update version and sha
- Remove noarch
- Update dependencies
- Add upstream tests
- Build for python 3.13
- Linter fixes

[PKG-6878]: https://anaconda.atlassian.net/browse/PKG-6878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ